### PR TITLE
Pass TypeId to directly query components

### DIFF
--- a/src/runtimes/bevy/ext/bevy_ecs/03_bevy_ecs.js
+++ b/src/runtimes/bevy/ext/bevy_ecs/03_bevy_ecs.js
@@ -100,23 +100,7 @@ ${err}`
       componentId() {
         return this.constructor.componentId;
       }
-
-      reflect() {
-        const obj = {};
-        obj[this.typeName()] = this;
-        return obj;
-      }
     };
-
-  // Call reflect method otherwise panic if not implemented
-  function unwrapReflect(reflectable) {
-    try {
-      return reflectable.reflect();
-    } catch (err) {
-      throw new Error(`Object must implement method "reflect" in order to be reflected:
-${err}`);
-    }
-  }
 
   class ReflectableObject extends Reflect(Object) {
     constructor(defaults, struct) {
@@ -169,7 +153,6 @@ ${err}`);
   }
   Object.assign(window.Bevy.ecs, {
     worldResourceId,
-    unwrapReflect,
     nextFrame,
     Bundle,
     Reflect,

--- a/src/runtimes/bevy/ext/bevy_ecs/04_entity.js
+++ b/src/runtimes/bevy/ext/bevy_ecs/04_entity.js
@@ -2,7 +2,7 @@
 
 ((window) => {
   const { core } = window.Deno;
-  const { unwrapReflect, Bundle } = window.Bevy.ecs;
+  const { Bundle } = window.Bevy.ecs;
 
   class Entity extends Map {
     constructor(worldResourceId, id) {
@@ -33,13 +33,12 @@ ${err}`
           );
         }
       } else {
-        let reflected = unwrapReflect(maybeComponent);
         try {
           core.ops.op_entity_insert_component(
             worldResourceId,
             id,
             maybeComponent.typeId(),
-            reflected
+            maybeComponent
           );
         } catch (err) {
           throw new Error(

--- a/src/runtimes/bevy/ext/bevy_ecs/05_query.js
+++ b/src/runtimes/bevy/ext/bevy_ecs/05_query.js
@@ -2,7 +2,7 @@
 
 ((window) => {
   const { core } = window.Deno;
-  const { unwrapReflect, worldResourceId } = window.Bevy.ecs;
+  const { worldResourceId } = window.Bevy.ecs;
 
   class Query {
     constructor() {}

--- a/src/runtimes/bevy/ext/bevy_ecs/entity.rs
+++ b/src/runtimes/bevy/ext/bevy_ecs/entity.rs
@@ -30,8 +30,6 @@ pub fn op_entity_insert_component(
     scope: &mut v8::HandleScope,
     world_resource_id: u32,
     entity_id: &[u8],
-    // TODO(https://github.com/bevyengine/bevy/issues/4597):
-    // Providing `type_id` necessary as long as component is dynamic
     type_id: &[u8],
     component: serde_v8::Value,
 ) -> Result<(), bjs::AnyError> {
@@ -40,11 +38,12 @@ pub fn op_entity_insert_component(
 
     let type_registry = world.resource::<AppTypeRegistry>().clone();
     let type_registry = type_registry.read();
+    let type_id = super::type_registry::bytes_to_type_id(type_id);
 
-    let component = bjs::runtimes::bevy::ext::deserialize(&type_registry, scope, component)?;
+    let component =
+        bjs::runtimes::bevy::ext::deserialize(&type_registry, type_id, scope, component)?;
     // TODO(https://github.com/bevyengine/bevy/issues/4597):
     // Lookup necessary as long as component is dynamic
-    let type_id = super::type_registry::bytes_to_type_id(type_id);
     let type_name = component.as_ref().type_name();
 
     // Verify `type_id` matches provided `component`


### PR DESCRIPTION
Removes all remaining object transformations on JS side when sending objects to Rust